### PR TITLE
Make the redirect check more precise

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -31,7 +31,7 @@ var fetchWellKnown = function (emitter, args, currentDomain, principalDomain, cl
 
   function handleResponse(err, statusCode, headers, body) {
     if (statusCode !== 200) {
-      if (Math.floor(statusCode / 100) === 3) {
+      if ([301, 302, 303, 307].indexOf(statusCode) !== -1) {
         return cb(currentDomain +
                   ' is not a browserid primary - redirection not supported for support documents');
       } else {


### PR DESCRIPTION
HTTP 304 (Not Modified) and 305 (Use Proxy) are not redirects so
they should probably not get the "redirects not allowed" error
message.

Not sure about 300 (Multiple Choices), but I left it out as well.
