### PR TITLE
Validate the authority field for delegating IdPs

### DIFF
--- a/lib/well-known-parser.js
+++ b/lib/well-known-parser.js
@@ -3,6 +3,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var jwcrypto = require("jwcrypto");
+var urlparse = require("urlparse");
+
+function validateAuthority(authority) {
+  // canary values
+  const scheme = 'https';
+  const directory = '/foo/';
+  const file = 'bar.html';
+  const query = 'q=blah';
+  const anchor = 'content';
+
+  var url = urlparse(scheme + "://" + authority + directory + file + '?' + query + '#' + anchor);
+
+  if (url.scheme !== scheme || url.authority !== authority ||
+      url.directory !== directory || url.file !== file ||
+      url.query !== query || url.anchor !== anchor) {
+    throw new Error("invalid hostname (scheme=" + url.scheme + ", authority=" + url.authority + ", directory=" + url.directory + ", file=" + url.file + ", query=" + url.query + ", anchor=" + anchor + ")");
+  }
+}
 
 // parse a well-known document.  throw an exception if it is invalid, return
 // a parsed version if it is valid.  return is an object having the following fields:
@@ -44,6 +62,11 @@ module.exports = function(doc, allowURLOmission) {
   if (doc.authority) {
     if (typeof doc.authority !== 'string') {
       throw "malformed authority";
+    }
+    try {
+      validateAuthority(doc.authority);
+    } catch (e) {
+      throw new Error("the authority is not a valid hostname");
     }
 
     return {

--- a/tests/well-known.js
+++ b/tests/well-known.js
@@ -46,6 +46,21 @@ describe('.well-known lookup, malformed', function() {
     });
   });
 
+  it('should reject invalid authorities', function(done) {
+    var x = idp.wellKnown();
+    x.authority = 'https://example.com';
+    idp.wellKnown(x);
+
+    browserid.lookup({ insecureSSL: true, domain: idp.domain() }, function(err) {
+      (err).should.contain("the authority is not a valid hostname");
+
+      // repair well-known
+      idp.wellKnown(null);
+
+      done();
+    });
+  });
+
   it('should properly parse disabled: true', function(done) {
     idp.wellKnown({ disabled: true });
 


### PR DESCRIPTION
The validation of that field should happen in the parser so that
invalid values never make it to the callers.
