### PR TITLE
Eliminate a variable reuse in claims extraction

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -155,15 +155,15 @@ function verify(browserid, args, cb) {
       }
 
       // extract extra idp claims
-      var extClaims = extractExtraClaims(idpClaims);
-      if (extClaims) {
-        obj.idpClaims = extClaims;
+      var extIdpClaims = extractExtraClaims(idpClaims);
+      if (extIdpClaims) {
+        obj.idpClaims = extIdpClaims;
       }
 
       // extract extra user claims
-      extClaims = extractExtraClaims(userClaims);
-      if (extClaims) {
-        obj.userClaims = extClaims;
+      var extUserClaims = extractExtraClaims(userClaims);
+      if (extUserClaims) {
+        obj.userClaims = extUserClaims;
       }
 
       // If the caller has expressed trust in a set of issuers, then we need not verify


### PR DESCRIPTION
These two sets of claims should always be kept completely separate
so let's use separate variables at all times when handling them.
