### PR TITLE
Validate provisioning and authentication endpoints

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -5,7 +5,6 @@
 var
 https = require('https'),
 wellKnownParser = require('./well-known-parser.js'),
-urlparse = require('urlparse'),
 _ = require('underscore');
 
 const WELL_KNOWN_URL = "/.well-known/browserid";
@@ -179,11 +178,9 @@ function lookup(emitter, args, currentDomain, principalDomain, cb, delegationCha
       try {
         if (supportDoc.paths.authentication) {
           details.urls.auth = url_prefix + supportDoc.paths.authentication;
-          urlparse(details.urls.auth).validate();
         }
         if (supportDoc.paths.provisioning) {
           details.urls.prov = url_prefix + supportDoc.paths.provisioning;
-          urlparse(details.urls.prov).validate();
         }
       } catch(e) {
         return cb("invalid URL in support document: " + e.toString());

--- a/lib/well-known-parser.js
+++ b/lib/well-known-parser.js
@@ -3,6 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var jwcrypto = require("jwcrypto");
+var urlparse = require("urlparse");
+
+function validateUrlPath(path) {
+  if (path[0] !== '/') {
+    throw new Error("paths must start with a slash");
+  }
+  urlparse("http://example.com" + path).validate();
+}
 
 // parse a well-known document.  throw an exception if it is invalid, return
 // a parsed version if it is valid.  return is an object having the following fields:
@@ -67,6 +75,7 @@ module.exports = function(doc, allowURLOmission) {
         throw "support document missing required '" + requiredKey + "'";
       }
     } else {
+      validateUrlPath(doc[requiredKey]);
       parsed.paths[requiredKey] = doc[requiredKey];
     }
   });

--- a/tests/well-known.js
+++ b/tests/well-known.js
@@ -46,6 +46,21 @@ describe('.well-known lookup, malformed', function() {
     });
   });
 
+  it('should reject invalid paths', function(done) {
+    var x = idp.wellKnown();
+    x.provisioning = 'foo';
+    idp.wellKnown(x);
+
+    browserid.lookup({ insecureSSL: true, domain: idp.domain() }, function(err) {
+      (err).should.contain("paths must start with a slash");
+
+      // repair well-known
+      idp.wellKnown(null);
+
+      done();
+    });
+  });
+
   it('should properly parse disabled: true', function(done) {
     idp.wellKnown({ disabled: true });
 


### PR DESCRIPTION
Let's do this closer to the data, not deep into the callers of the
well-known parser.
