### PR TITLE
Stricter disabled

### DIFF
--- a/lib/well-known-parser.js
+++ b/lib/well-known-parser.js
@@ -32,12 +32,11 @@ module.exports = function(doc, allowURLOmission) {
   // 3. "disable" - domain declares explicitly that it wants a secondary
   //    to be authoritative.
 
-  // is this a "disable" document?  Any value will cause the domain to
-  // be disabled for the purposes of parsing.  For the purposes of the spec
-  // we should insist on 'true'.  Rationale is that if disabled is present
-  // in the file, the most likely intent is to DISABLE.
-  if (doc.disabled) {
+  // is this a "disable" document?
+  if (doc.disabled === true) {
     return { type: "disabled" };
+  } else if (doc.disabled !== undefined && doc.disabled !== false) {
+    throw new Error("disabled must be either true or false");
   }
 
   // is this a delegation document?

--- a/tests/well-known.js
+++ b/tests/well-known.js
@@ -76,6 +76,36 @@ describe('.well-known lookup, malformed', function() {
     });
   });
 
+  it('should properly parse disabled: 0', function(done) {
+    var x = idp.wellKnown();
+    x.disabled = 0;
+    idp.wellKnown(x);
+
+    browserid.lookup({ insecureSSL: true, domain: idp.domain() }, function(err) {
+      (err).should.contain('disabled must be either true or false');
+
+      // repair well-known
+      idp.wellKnown(null);
+
+      done();
+    });
+  });
+
+  it('should properly parse disabled: "true"', function(done) {
+    var x = idp.wellKnown();
+    x.disabled = "true";
+    idp.wellKnown(x);
+
+    browserid.lookup({ insecureSSL: true, domain: idp.domain() }, function(err) {
+      (err).should.contain('disabled must be either true or false');
+
+      // repair well-known
+      idp.wellKnown(null);
+
+      done();
+    });
+  });
+
   it('shutdown of IdP should succeed', function(done) {
     idp.stop(done);
   });


### PR DESCRIPTION
While we could be more tolerant here than in the spec, the risk is
that the majority of developers will not read the spec and will
instead try something with our verifier and expect that it will
always continue to work the same way.

In other words, if we're too lenient at the start, we will be
stuck supporting an alternative syntax forever and will impose that
on third-party verifiers as well.
