### PR TITLE
Validate the princpal and current domains in lookup

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -6,6 +6,7 @@ var
 http = require('http'),
 https = require('https'),
 urlparse = require('urlparse'),
+validation = require('./validation.js'),
 wellKnownParser = require('./well-known-parser.js');
 
 const WELL_KNOWN_URL = "/.well-known/browserid";
@@ -169,6 +170,19 @@ function lookup(emitter, args, currentDomain, principalDomain, cb, delegationCha
   }
   if (!delegationChain) {
     delegationChain = [ principalDomain ];
+  }
+
+  try {
+    validation.validateAuthority(principalDomain);
+  } catch (e) {
+    return cb("invalid domain: " + principalDomain);
+  }
+  if (currentDomain !== principalDomain) {
+    try {
+      validation.validateAuthority(currentDomain);
+    } catch (e) {
+      return cb("invalid domain: " + currentDomain);
+    }
   }
 
   fetchWellKnown(emitter, args, currentDomain, principalDomain, function(err, unparsedDoc) {

--- a/tests/lookup.js
+++ b/tests/lookup.js
@@ -204,6 +204,14 @@ describe('.well-known lookup transport tests (HTTP)', function() {
     });
   });
 
+  it('should fail on invalid domains', function(done) {
+    browserid.lookup({ domain: 'http://example.com' }, function(err) {
+      should.exist(err);
+      (err).should.startWith('invalid domain:');
+      done(null);
+    });
+  });
+
   it('test servers should shut down', function(done) {
     async.parallel([
       function(cb) {


### PR DESCRIPTION
This patch includes a copy of the `validateAuthority` function introduced in #10 and so it will need to be refactored once/if both of these patches are merged.
