### PR TITLE
Validate the domain that's extracted from the cert email

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -58,8 +58,26 @@ function extractExtraClaims(claims) {
   return Object.keys(extraClaims).length ? extraClaims : null;
 }
 
+function validateAuthority(authority) {
+  // canary values
+  const scheme = 'https';
+  const directory = '/foo/';
+  const file = 'bar.html';
+  const query = 'q=blah';
+  const anchor = 'content';
+
+  var url = urlparse(scheme + "://" + authority + directory + file + '?' + query + '#' + anchor);
+  if (url.scheme !== scheme || url.authority !== authority ||
+      url.directory !== directory || url.file !== file ||
+      url.query !== query || url.anchor !== anchor) {
+    throw new Error("invalid hostname");
+  }
+}
+
 function extractDomainFromEmail(email) {
-  return (/\@(.*)$/).exec(email)[1].toLowerCase();
+  var domain = (/\@(.*)$/).exec(email)[1].toLowerCase();
+  validateAuthority(domain);
+  return domain;
 }
 
 function verify(browserid, args, cb) {

--- a/tests/assertion.js
+++ b/tests/assertion.js
@@ -77,6 +77,28 @@ describe('assertion verification, basic', function() {
     });
   });
 
+  it('validation of assertion with an invalid hostname in the email should fail', function(done) {
+    client = new Client({
+      idp: idp,
+      email: 'test@example/com'
+    });
+
+    // allocate a new "client".  She has an email and idp as specified below
+    // generate an assertion (and all pre-requisites)
+    client.assertion({ audience: 'http://example.com' }, function(err, assertion) {
+      browserid.verify({
+        fallback: idp.domain(),
+        httpTimeout: 0.1,
+        assertion: assertion,
+        audience: 'http://example.com'
+      }, function(err) {
+        should.exist(err);
+        err.should.contain("untrusted assertion, doesn't contain an email, and issuer is untrusted");
+        done();
+      });
+    });
+  });
+
   it('test idp should shut down', function(done) {
     idp.stop(done);
   });


### PR DESCRIPTION
As in #21, this patch includes a copy of the validateAuthority function introduced in #10 and so it will need to be refactored once/if both of these patches are merged.
