### PR TITLE
Add missing require for urlparse

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -5,6 +5,7 @@
 var
 http = require('http'),
 https = require('https'),
+urlparse = require('urlparse'),
 wellKnownParser = require('./well-known-parser.js');
 
 const WELL_KNOWN_URL = "/.well-known/browserid";


### PR DESCRIPTION
This was removed as part of a refactoring in 5ecb9318a95ce5ac4b945f493cd2644e63a5e4ee
but it should have been kept since dd1b6ec9eda3a81ead2bdf3662d849b3d2ee5c8c
introduced extra uses of that module.
