### PR TITLE
Restore audience mismatch error messages

### DIFF
--- a/lib/compare-audiences.js
+++ b/lib/compare-audiences.js
@@ -20,11 +20,11 @@ function compareAudiences(want, got) {
   }
 
   try {
-    var got_protocol, got_hostname, got_port;
+    var got_protocol, got_hostname, got_port, got_path;
 
     // We allow the RP to provide audience in multiple forms (see issue #82).
-    // The RP SHOULD provide full origin, but we allow these alternate forms for
-    // some dude named Postel doesn't go postal.
+    // The RP SHOULD provide full origin, but we allow these alternate forms
+    // so that some dude named Postel doesn't go postal.
     // 1. full origin 'http://rp.tld'
     // 1a. full origin with port 'http://rp.tld:8080'
     // 2. domain and port 'rp.tld:8080'
@@ -39,6 +39,7 @@ function compareAudiences(want, got) {
     got_protocol = gu.protocol;
     got_hostname = gu.hostname;
     got_port = gu.port;
+    got_path = gu.path;
 
     // now parse "want" url
     want = normalizeParsedURL(url.parse(want));
@@ -51,6 +52,9 @@ function compareAudiences(want, got) {
     }
     if (got_hostname !== want.hostname) {
       throw new Error("domain mismatch");
+    }
+    if (got_path && got_path !== "/") {
+      throw new Error("has non-empty path");
     }
 
     return undefined;

--- a/tests/audience-matching.js
+++ b/tests/audience-matching.js
@@ -44,7 +44,7 @@ describe('audience matching', function() {
 
   it('should catch malformed domains', function(done) {
     var err = compareAudiences("http://example.com", "example.com::80");
-    should(err).equal("domain mismatch");
+    should(err).equal("has non-empty path");
     done();
   });
 


### PR DESCRIPTION
A recent change caused audience mismatch error messages to go from this:

```
"audience mismatch: domain mismatch"
```

To this:

```
"audience misatch: Error: domain mismatch"
```

This repo didn't have tests for the error message, but browserid-verify does and they started failing when I updated the dependency there.  This PR restores the messages to their previous value, which IMHO is nicer.  It also adds some tests and fixes a test that should have been failing, but wasn't.

@fmarier r?
