### PR TITLE
Update to latest browserid-crypto.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Lloyd <lloyd@hilaiel.com> (http://lloyd.io)",
   "name": "browserid-local-verify",
   "description": "A node.js verification library for local verification of BrowserID assertions.",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "repository": {
     "url": "https://github.com/mozilla/browserid-local-verify"
   },
@@ -11,7 +11,7 @@
   },
   "main": "lib/browserid-local-verify",
   "dependencies": {
-    "browserid-crypto": "0.6.1",
+    "browserid-crypto": "0.7.0",
     "async": "0.2.9",
     "dbug": "0.4.1",
     "urlparse": "0.0.1",

--- a/tests/key-types.js
+++ b/tests/key-types.js
@@ -16,11 +16,11 @@ async = require('async');
 
 describe('key size and type', function() {
   const keyTypes = [
-    { algorithm: 'rsa', keysize: 64 },
-    { algorithm: 'rsa', keysize: 128 },
-    { algorithm: 'rsa', keysize: 256 },
-    { algorithm: 'dsa', keysize: 128 },
-    { algorithm: 'dsa', keysize: 256 }
+    { algorithm: 'RS', keysize: 64 },
+    { algorithm: 'RS', keysize: 128 },
+    { algorithm: 'RS', keysize: 256 },
+    { algorithm: 'DS', keysize: 128 },
+    { algorithm: 'DS', keysize: 256 }
   ];
 
   // a local idp with a 1s delay in serving support documents

--- a/tests/lib/client.js
+++ b/tests/lib/client.js
@@ -18,11 +18,11 @@ function Client(args) {
   this.args = args;
   this.args.idp = args.idp;
   this.args.email = args.email || 'test@' + args.idp.domain();
-  this.args.algorithm = this.args.algorithm || "dsa";
+  this.args.algorithm = this.args.algorithm || "DS";
   this.args.keysize = this.args.keysize || 128;
   this.args.delegation = this.args.delegation || null;
 
-  // allow algorithm specification as (i.e.) 'rsa' or 'RS'
+  // allow algorithm specification as (i.e.) 'rs' or 'RS'
   this.args.algorithm = this.args.algorithm.toUpperCase();
 }
 

--- a/tests/lib/delegation.js
+++ b/tests/lib/delegation.js
@@ -24,7 +24,7 @@ function stop(cb) {
 module.exports = function(num, cb) {
   async.times(num, function(x, done) {
     var idp = new IdP({
-      algorithm: 'dsa',
+      algorithm: 'DS',
       keysize: 128
     });
     idp.start(function(err) {

--- a/tests/lib/idp.js
+++ b/tests/lib/idp.js
@@ -28,11 +28,11 @@ function IdP(args) {
   this.args = args;
   // default paramter values
   this.args.delay = this.args.delay || 0;
-  this.args.algorithm = this.args.algorithm || "rsa";
+  this.args.algorithm = this.args.algorithm || "RS";
   this.args.keysize = this.args.keysize || 128;
   this.args.delegation = this.args.delegation || null;
 
-  // allow algorithm specification as (i.e.) 'rsa' or 'RS'
+  // allow algorithm specification as (i.e.) 'rs' or 'RS'
   this.args.algorithm = this.args.algorithm.toUpperCase();
 
   if (args.wellKnown) this.wellKnown(args.wellKnown);


### PR DESCRIPTION
The latest browserid-crypto removed support for "new format"
certificates and assertions, which required some slight tweaks to the
tests.

We _could_ keep the "RSA"/"DSA" compatability hooks for algorithm name as part of browserid-crypto, which would make this PR just a version bump.  But IIUC they were never used in the wild, so it seems prudent to be strict and catch potential incompatibilities early.

@fmarier r? in combination with https://github.com/mozilla/browserid-crypto/pull/103
