### PR TITLE
Remove additional uses of 'urlparse' module

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -6,7 +6,6 @@ var
 dbug = require('dbug')('browserid-local-verify:lookup'),
 http = require('http'),
 https = require('https'),
-urlparse = require('urlparse'),
 validation = require('./validation.js'),
 wellKnownParser = require('./well-known-parser.js');
 
@@ -45,7 +44,7 @@ var shouldUseProxy = function(host) {
   if (!httpsProxy) {
     return null;
   }
-  httpsProxy = urlparse(httpsProxy).validate();
+  httpsProxy = validation.validateUrl(httpsProxy);
   // Check if this host is exclued via the no-proxy list.
   var noProxy = process.env.no_proxy || process.env.NO_PROXY;
   if (noProxy) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -21,6 +21,50 @@ function validateAuthority(authority) {
       url.auth !== null) {
     throw new Error("invalid hostname");
   }
+
+  return authority;
 }
 
 module.exports.validateAuthority = validateAuthority;
+
+function validateUrl(url) {
+  var port;
+  url = urlparse(url);
+  if (!url.protocol) {
+    throw new Error("invalid url: missing protocol");
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error("invalid url: unsupported scheme: " + url.protocol);
+  }
+  if (!url.hostname) {
+    throw new Error("invalid url: missing hostname");
+  }
+  if (url.port) {
+    // url.parse ensurses the port is a str repr of a positive integer.
+    port = parseInt(url.port);
+    if (parseInt(url.port) >= 65536) {
+      new Error("invalid url: port out of range: " +this.port);
+    }
+  }
+  return {
+    // remove trailing ":"
+    scheme: url.protocol.slice(0, url.protocol.length - 1),
+    host: url.hostname,
+    port: url.port ? port : undefined,
+    path: url.pathname
+  };
+}
+
+module.exports.validateUrl = validateUrl;
+
+function validateUrlPath(path) {
+  if (path[0] !== '/') {
+    throw new Error("invalid path: must start with a slash");
+  }
+  if (path !== validateUrl("http://example.com" + path).path) {
+    throw new Error("invalid path");
+  }
+  return path;
+}
+
+module.exports.validateUrlPath = validateUrlPath;

--- a/lib/well-known-parser.js
+++ b/lib/well-known-parser.js
@@ -3,15 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var jwcrypto = require("browserid-crypto");
-var urlparse = require("urlparse");
 var validation = require('./validation.js');
-
-function validateUrlPath(path) {
-  if (path[0] !== '/') {
-    throw new Error("paths must start with a slash");
-  }
-  urlparse("http://example.com" + path).validate();
-}
 
 // parse a well-known document.  throw an exception if it is invalid, return
 // a parsed version if it is valid.  return is an object having the following fields:
@@ -80,7 +72,7 @@ module.exports = function(doc) {
     if (typeof doc[requiredKey] !== 'string') {
       throw new Error("support document missing required property: '" + requiredKey + "'");
     } else {
-      validateUrlPath(doc[requiredKey]);
+      validation.validateUrlPath(doc[requiredKey]);
       parsed.paths[requiredKey] = doc[requiredKey];
     }
   });

--- a/tests/well-known.js
+++ b/tests/well-known.js
@@ -116,7 +116,7 @@ describe('.well-known lookup, malformed', function() {
     idp.wellKnown(x);
 
     browserid.lookup({ insecureSSL: true, domain: idp.domain() }, function(err) {
-      (err).should.contain("paths must start with a slash");
+      (err).should.contain("must start with a slash");
 
       // repair well-known
       idp.wellKnown(null);


### PR DESCRIPTION
@fmarier this removes some additional uses of the old `urlparse` module, replacing them with some straightforward extra checks on the result of the builtin `url.parse` function.  I'm going to merge and release it when travis goes green, because I forgot to do this as part of the v0.3.0 release, so current release version is busted :-(

But if you get a chance, an r? would still be appreciated.