### PR TITLE
Cache checks on whether to use a proxy, rather than checking each time.

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -38,30 +38,94 @@ var getWithTransparentProxying = function(options, cb) {
   return httpmod.get(options, cb);
 };
 
-var shouldUseProxy = function(host) {
-  // Check if we have a proxy configured for https urls.
-  var httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
-  if (!httpsProxy) {
-    return null;
-  }
-  httpsProxy = validation.validateUrl(httpsProxy);
-  // Check if this host is exclued via the no-proxy list.
-  var noProxy = process.env.no_proxy || process.env.NO_PROXY;
-  if (noProxy) {
-    if (noProxy === '*') {
-      return null;
+
+
+// It's very convenient for calling code (e.g. tests) to be able to tweak
+// process.env.HTTPS_PROXY and friends and have the results apply immediately,
+// but changes to the env vars are highly unlikely when running in production.
+// To avoid the overhead of parsing and validating env vars on every lookup,
+// we generate a specialized implementation of the shouldUseProxy(host)
+// function and invalidate it if we find the env vars have changed.
+
+var shouldUseProxy = (function() {
+
+  function updateShouldUseProxyFunction() {
+
+    var httpsProxy, noProxy, proxyDetails, noProxyList;
+
+    // Cache current env var values into local variables.
+    // We check these before calling the specialized implementation.
+
+    httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+    if (httpsProxy) {
+      noProxy = process.env.no_proxy || process.env.NO_PROXY;
     }
-    var noProxyList = noProxy.split(/,\s*/);
-    for (var i = 0; i < noProxyList.length; i++) {
-      var suffix = noProxyList[i];
-      if (host.lastIndexOf(suffix) === host.length - suffix.length) {
-        return null;
+
+    function checkEnvCache() {
+      if (httpsProxy !== (process.env.https_proxy || process.env.HTTPS_PROXY)) {
+        return false;
+      }
+      if (httpsProxy) {
+        if (noProxy !== (process.env.no_proxy || process.env.NO_PROXY)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // Given cached env vars, there are three possible implementations:
+    //  * never use a proxy
+    //  * always use a specific proxy
+    //  * use a specific proxy, but check hostname in a specific list
+
+    var implUseProxyNever = function shouldUseProxy(host) {
+      if (!checkEnvCache()) { return updateShouldUseProxyFunction()(host); }
+      return null;
+    };
+
+    var implUseProxyAlways = function shouldUseProxy(host) {
+      if (!checkEnvCache()) { return updateShouldUseProxyFunction()(host); }
+      return proxyDetails;
+    };
+
+    var implUseProxyWithExcludeList = function shouldUseProxy(host) {
+      if (!checkEnvCache()) { return updateShouldUseProxyFunction()(host); }
+      for (var i = 0; i < noProxyList.length; i++) {
+        var suffix = noProxyList[i];
+        if (host.lastIndexOf(suffix) === host.length - suffix.length) {
+          return null;
+        }
+      }
+      return proxyDetails;
+    };
+
+    // Pick which implementation to use based on the env vars.
+
+    if (!httpsProxy) {
+      // No proxy configured for https urls?  Never use one.
+      shouldUseProxy = implUseProxyNever;
+    } else {
+      proxyDetails = validation.validateUrl(httpsProxy);
+      if (!noProxy) {
+        // No list of hosts to exclude?  Always use the proxy.
+        shouldUseProxy = implUseProxyAlways;
+      } else {
+        if (noProxy === '*') {
+          // All hosts are excluded?  Never use the proxy.
+          shouldUseProxy = implUseProxyNever;
+        } else {
+          // We have to check against the exclude list.
+          noProxyList = noProxy.split(/,\s*/);
+          shouldUseProxy = implUseProxyWithExcludeList;
+        }
       }
     }
+
+    return shouldUseProxy;
   }
-  // Yep, we need to use the proxy.
-  return httpsProxy;
-};
+
+  return updateShouldUseProxyFunction();
+})();
 
 
 // hit the network and fetch a .well-known document in its unparsed form


### PR DESCRIPTION
Sorry @mostlygeek, but you sent me down a Freaky Friday rabbit hole...

Here's something that might help with the CPU usage issue identified in https://github.com/mozilla/browserid-verifier/issues/80.  The current code checks for and validates proxy-related environment variables on every remote request.  This version generates a specialized checking function based on the current env var values, and only changes it if it finds that the env vars have mysteriously changed.

In a simple local test calling `shouldUseProxy` 1000000 times in a loop, this version is very slightly slower when there's no `HTTPS_PROXY` env var, and more than five times faster when there is.

Kinda complicated, but good fun and might be worth it to save a few pennies a day :-P