### PR TITLE
Explicitly guard against port <= 0 in URL validation

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -42,8 +42,8 @@ function validateUrl(url) {
   if (url.port) {
     // url.parse ensurses the port is a str repr of a positive integer.
     port = parseInt(url.port);
-    if (parseInt(url.port) >= 65536) {
-      new Error("invalid url: port out of range: " +this.port);
+    if (port <= 0 || port >= 65536) {
+      throw new Error("invalid url: port out of range: " +this.port);
     }
   }
   return {

--- a/tests/validation.js
+++ b/tests/validation.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global describe,it */
+
+const
+should = require('should'),
+validation = require('../lib/validation');
+
+describe('url validation', function() {
+
+  it('should reject badly-formed urls', function(done) {
+    var INVALID_URLS = [
+      "!@#%!$^!^$",
+      "://host.com",
+      "bogus://apps.mozillalabs.com",
+      "http:",
+      "http://host.com:76543",
+      "http://host.com:0",
+    ];
+    INVALID_URLS.forEach(function(invalidUrl) {
+      should.throws(function() {
+        validation.validateUrl(invalidUrl);
+      });
+    });
+    done();
+  });
+
+});


### PR DESCRIPTION
The url parser itself will not accept negative port values, but it allows zero.  So we may as well put in a full explicit check for ourselves.  This also copies over some testcases from the urlparse library, which naturally identified a bug in the port-handling code anyway...

@vladikoff r?