### PR TITLE
feat(lookup): Allow forcing lookup over http, for testing purposes.

### DIFF
--- a/lib/browserid-local-verify.js
+++ b/lib/browserid-local-verify.js
@@ -12,7 +12,8 @@ function Verifier(args) {
   this.args = _.extend({
     'maxDelegations': 5,
     'httpTimeout': 10.0,
-    'insecureSSL': false
+    'insecureSSL': false,
+    'forceInsecureLookupOverHTTP': false
   }, args);
 }
 

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -19,6 +19,7 @@ const DEFAULT_PORTS = {
 // like https.get() but transparently supports the
 // $https_proxy and $no_proxy environment variables.
 var getWithTransparentProxying = function(options, cb) {
+  options = options || {};
   var httpmod = options.httpmod || https;
   var proxy = shouldUseProxy(options.host);
   if (proxy) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -19,7 +19,7 @@ const DEFAULT_PORTS = {
 // like https.get() but transparently supports the
 // $https_proxy and $no_proxy environment variables.
 var getWithTransparentProxying = function(options, cb) {
-  var httpmod = https;
+  var httpmod = options.httpmod || https;
   var proxy = shouldUseProxy(options.host);
   if (proxy) {
     if (proxy.scheme === 'http') {
@@ -130,6 +130,7 @@ var fetchWellKnown = function (emitter, args, currentDomain, principalDomain, cl
       port: port,
       path: pathToWellKnown,
       rejectUnauthorized: !args.insecureSSL,
+      httpmod: (!! args.forceInsecureLookupOverHTTP) ? http : https,
       agent: false
     }, function(res) {
       var body = "";


### PR DESCRIPTION
For https://github.com/mozilla/browserid-verifier/issues/106