### PR TITLE
fix(deps): Update to node10-compatible browserid-crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ dist: trusty
 sudo: required
 
 node_js:
-  - "0.10"
-  - "4"
+  - "8"
+  - "10"
  
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "lib/browserid-local-verify",
   "dependencies": {
-    "browserid-crypto": "0.9.0",
+    "browserid-crypto": "0.9.1",
     "async": "2.0.1",
     "dbug": "0.4.2",
     "optimist": "0.6.1",


### PR DESCRIPTION
This won't pass until we release a new version of browserid-crypto to include https://github.com/mozilla/browserid-crypto/pull/113, but prepping it in the meantime...